### PR TITLE
Fix timings again

### DIFF
--- a/src/jscwlib.js
+++ b/src/jscwlib.js
@@ -1353,7 +1353,7 @@
                     var ti = this.gen_morse_timing(c, time);
                     ti[0]['c'] = {"n": i, "c": c };  // in the first element, include the character and the position, so we can fire the onCharacterPlay function
                     out = out.concat(ti);
-                    time += this.wordspace;  // NOTE: this.wordspace is actually a wordspace minus a letter space; this composates the fact that each letter is followed by a letter space
+                    time += this.wordspace;  // NOTE: this.wordspace is actually a wordspace minus a letter space; this compensates the fact that each letter is followed by a letter space
                     if (this.ews) {
                         time += (this.wordspace + this.letterspace) * this.ews;
                     }

--- a/src/jscwlib.js
+++ b/src/jscwlib.js
@@ -1200,11 +1200,7 @@
             }
 
             if (this.onFinished) {
-                // although setValueAtTime changes the value of this.gainNode
-                // immediately, the low-pass filter will slightly delay the end
-                // of the actual signal; value of 30 ms found empirically
-                const finishTime = this.getRemaining() + 0.030;
-                this.timers.push(setTimeout(this.onFinished, finishTime * 1000));
+                this.timers.push(setTimeout(this.onFinished, this.getRemaining() * 1000));
             }
         } // setTimers
 

--- a/src/jscwlib.js
+++ b/src/jscwlib.js
@@ -76,10 +76,12 @@
             "(": "-.--.",  // Left-hand bracket (parenthesis)
             ")": "-.--.-",  // Right-hand bracket (parenthesis)
             // Inverted commas (before and after the words)
-            // English
+            // Straight quotes
+            '"': ".-..-.",
+            // English quotes
             "“": ".-..-.",
             "”": ".-..-.",
-            // French
+            // French quotes
             "«": ".-..-.",
             "»": ".-..-.",
             "=": "-...-",  // Double hyphen
@@ -129,12 +131,11 @@
             "″": ".----. .----.",
 
             // Non-standard punctuation marks
-            "\"": ".-..-.",
-            "!": "..--.",
+            "!": "..--.",  // mapped to interrogation mark
             "$": "...-..-",
             "`": ".-----.",
-            "&": ". ...",
             ";": "-.-.-.",
+            "&": ". ...",  // "es"
 
             // non-Latin extensions (from https://en.wikipedia.org/wiki/Morse_code#Letters,_numbers,_punctuation,_prosigns_for_Morse_code_and_non-Latin_variants)
             // Uppercase    Lowercase

--- a/src/jscwlib.js
+++ b/src/jscwlib.js
@@ -1204,7 +1204,7 @@
                 // immediately, the low-pass filter will slightly delay the end
                 // of the actual signal; value of 30 ms found empirically
                 const finishTime = this.getRemaining() + 0.030;
-                this.timers.push(setTimeout(this.onFinished, finishTime * 1000 - this.playStart));
+                this.timers.push(setTimeout(this.onFinished, finishTime * 1000));
             }
         } // setTimers
 

--- a/src/jscwlib.js
+++ b/src/jscwlib.js
@@ -779,7 +779,7 @@
             }
 
             if (r >= 0) {
-                return Math.round(r*10)/10;;
+                return r;
             }
             else {
                 return 0;


### PR DESCRIPTION
Hello @dj1yfk,

I eventually noticed the bug from “Remove unnecessary rounding”, but you have already reverted it.

This PR is mostly about another subtle issue in the timing of `onFinished`. I have determined that the subtraction of `this.playStart` is actually not necessary when scheduling the `onFinished` event. Removing it is the proper fix for the issue I had tried to address in `dea12a23f41ba0c670555b6e679e4f30ae1e7cda`, so I have removed the work-around I had added (addind a 30 ms delay).

With these changes, I do not have any timing issue with `onFinished` anymore.

This time, I have also tested the built-in player (`onCharacterPlay` & `onFinished`, without pausing, with pausing, and when playing a second time), to avoid introducing a bug as I did with “Remove unnecessary rounding”.